### PR TITLE
70: Add Prometheus and Grafana monitoring baseline

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -99,3 +99,10 @@ Kein Projektbericht, keine Historie, kein Story-Log.
 - Für CI-nahe Frontend-Validierung `vitest run` statt Watch-Mode verwenden; `npm test` kann lokal grün sein, aber ohne `run` nicht deterministisch terminieren.
 - **PR-Review (Issue #64):** Mock-Call-Assertions in asynchronen Tests immer in `waitFor` wrappen und `toHaveBeenLastCalledWith` + `toHaveBeenCalledTimes` kombinieren — einzelne naïve `expect(mock).toHaveBeenCalledWith(...)` ohne `waitFor` können bei debounced Effekten flaky sein (Race Condition zwischen DOM-Event und Timer-Auflösung).
 - **PR-Review (Issue #64):** Exakte Test-Zählungen (z. B. „295/296 Tests") in Dokumenten/README nicht hart kodieren — Zahlen driften bei jedem neuen Test und führen zu irreführendem Veraltungs-Overhead. Stattdessen CI-Status als autoritative Quelle referenzieren.
+
+## Ergänzung Issue #70 (Prometheus/Grafana Monitoring Baseline)
+
+- Prometheus-Instrumentierung für FastAPI zentral an der App-Fabrik verdrahten und im Test-App-Setup spiegeln, damit `/metrics` in Runtime **und** Tests konsistent verfügbar ist.
+- Für Exporter-Container keine Healthchecks verwenden, die auf nicht garantiert vorhandene Tools wie `wget`/`curl` angewiesen sind; lieber image-native Self-Checks oder stabile HTTP-Probes nutzen.
+- VSCode-Readiness-Tasks robuster über Docker-Health + expliziten App-Health-Endpunkt prüfen als über hostseitige Inline-Python-Probes mit indirekter Exit-Code-Auswertung.
+- Monitoring-Dashboards und Alert-Regeln als provisionierte Dateien versionieren; UI-only-Konfiguration driftet sonst schnell von Compose/Dokumentation weg.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ npm run build
 - MinIO (Port 9000/9001)
 - Meilisearch v1.6.0 (Port 7700)
 - FastAPI App (Port 8000)
+- Prometheus (Port 9090)
+- Grafana (Port 3001)
+- PostgreSQL Exporter (Port 9187)
+- Redis Exporter (Port 9121)
 
 ```bash
 # Services starten
@@ -221,8 +225,12 @@ docker-compose down
 **Zugriff**:
 - API: http://localhost:8000
 - Swagger: http://localhost:8000/docs
+- Prometheus: http://localhost:9090
+- Grafana: http://localhost:3001 (admin/admin)
 - MinIO Console: http://localhost:9001 (minioadmin/minioadmin)
 - Meilisearch: http://localhost:7700
+
+Monitoring-Runbook: [doc/MONITORING_SETUP.md](doc/MONITORING_SETUP.md)
 
 **Umgebungsvariablen**: Siehe `.env.example` für alle Konfigurationsoptionen.
 

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from app.modules.auth.router import get_auth_router
 from app.modules.nanos.router import get_nanos_router
 from app.modules.search.router import get_search_router
 from app.modules.upload.router import get_upload_router
+from app.monitoring import configure_monitoring
 from app.redis_client import check_redis_health, close_redis, get_redis
 
 settings = get_settings()
@@ -65,6 +66,7 @@ def create_app() -> FastAPI:
     app.include_router(get_upload_router())
     app.include_router(get_nanos_router())
     app.include_router(get_search_router())
+    configure_monitoring(app)
 
     @app.get("/health")
     async def health_check() -> dict:

--- a/app/monitoring.py
+++ b/app/monitoring.py
@@ -1,0 +1,15 @@
+"""Monitoring configuration for FastAPI Prometheus metrics."""
+
+from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
+
+METRICS_ENDPOINT = "/metrics"
+
+
+def configure_monitoring(app: FastAPI) -> None:
+    """Enable Prometheus instrumentation and expose metrics endpoint."""
+    Instrumentator().instrument(app).expose(
+        app,
+        include_in_schema=False,
+        endpoint=METRICS_ENDPOINT,
+    )

--- a/doc/MONITORING_SETUP.md
+++ b/doc/MONITORING_SETUP.md
@@ -1,0 +1,94 @@
+# Monitoring Setup (Prometheus/Grafana Baseline)
+
+This document describes the reproducible local/staging-like monitoring baseline for Story 7.5.
+
+## Scope
+
+- Prometheus metrics collection
+- Grafana dashboard provisioning
+- FastAPI application metrics via `/metrics`
+- PostgreSQL metrics via `postgres_exporter`
+- Redis metrics via `redis_exporter`
+- Baseline alert rules (`HighErrorRate`, `SlowAPI`)
+
+## Included Components
+
+The stack is defined in `docker-compose.yml`:
+
+- `prometheus` (`http://localhost:9090`)
+- `grafana` (`http://localhost:3001`)
+- `postgres_exporter` (`http://localhost:9187/metrics`)
+- `redis_exporter` (`http://localhost:9121/metrics`)
+
+Application and storage services provide scrape targets via compose networking:
+
+- `app:8000/metrics`
+- `postgres_exporter:9187/metrics`
+- `redis_exporter:9121/metrics`
+
+## Reproducible Compose Workflow
+
+```powershell
+docker compose pull
+docker compose up -d --remove-orphans
+docker compose ps
+```
+
+To stop and clean up:
+
+```powershell
+docker compose down
+```
+
+## Validation Checklist
+
+1. Prometheus target status:
+   - Open `http://localhost:9090/targets`
+   - Ensure jobs `fastapi`, `postgres_exporter`, `redis_exporter` are `UP`
+
+2. FastAPI metrics endpoint:
+   - Open `http://localhost:8000/metrics`
+   - Confirm Prometheus text format output (`# HELP`, `# TYPE` lines)
+
+3. Grafana dashboards:
+   - Open `http://localhost:3001`
+   - Login with `admin/admin` (dev defaults)
+   - Verify dashboards exist in folder `DiWeiWei`:
+     - `API Overview`
+     - `DB Health`
+     - `Infrastructure Health`
+
+4. Alert rules:
+   - Open `http://localhost:9090/rules`
+   - Confirm rules:
+     - `HighErrorRate`
+     - `SlowAPI`
+
+## Files and Configuration
+
+- Prometheus scrape + rules:
+  - `monitoring/prometheus/prometheus.yml`
+  - `monitoring/prometheus/alerts.yml`
+- Grafana provisioning:
+  - `monitoring/grafana/provisioning/datasources/datasource.yml`
+  - `monitoring/grafana/provisioning/dashboards/dashboards.yml`
+- Dashboards:
+  - `monitoring/grafana/dashboards/api-overview.json`
+  - `monitoring/grafana/dashboards/db-health.json`
+  - `monitoring/grafana/dashboards/infrastructure-health.json`
+
+## Credentials and Secrets
+
+- This baseline intentionally uses local development credentials (`admin/admin` for Grafana and compose defaults for internal services).
+- No production credentials are committed in this setup.
+- For non-local environments, override credentials via environment variables:
+  - `GRAFANA_ADMIN_USER`
+  - `GRAFANA_ADMIN_PASSWORD`
+  - Existing DB/Redis credentials from `.env` / compose environment
+
+## Alert Rule Notes
+
+- `HighErrorRate` triggers when the 5xx ratio exceeds 5% over a 5-minute rate window for 2 minutes.
+- `SlowAPI` triggers when p95 request latency exceeds 1 second over a 5-minute rate window for 2 minutes.
+
+Both rules are designed as baseline operational signals for MVP and can be tightened in later hardening phases.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,12 +181,110 @@ services:
       - diwei_dev
     restart: unless-stopped
 
+  # PostgreSQL Exporter - Prometheus metrics bridge
+  postgres_exporter:
+    image: prometheuscommunity/postgres-exporter:v0.16.0
+    container_name: diwei_dev_postgres_exporter
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-diwei_user}:${POSTGRES_PASSWORD:-diwei_password}@postgres:5432/${POSTGRES_DB:-diwei_nano_market}?sslmode=disable"
+    ports:
+      - "9187:9187"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:9187/metrics"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - diwei_dev
+    restart: unless-stopped
+
+  # Redis Exporter - Prometheus metrics bridge
+  redis_exporter:
+    image: oliver006/redis_exporter:v1.67.0
+    container_name: diwei_dev_redis_exporter
+    environment:
+      REDIS_ADDR: "redis://redis:6379"
+    ports:
+      - "9121:9121"
+    healthcheck:
+      test: ["CMD", "/redis_exporter", "--version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - diwei_dev
+    restart: unless-stopped
+
+  # Prometheus - Metrics collection and alert evaluation
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: diwei_dev_prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    ports:
+      - "9090:9090"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:9090/-/healthy"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus_data:/prometheus
+    depends_on:
+      app:
+        condition: service_healthy
+      postgres_exporter:
+        condition: service_healthy
+      redis_exporter:
+        condition: service_healthy
+    networks:
+      - diwei_dev
+    restart: unless-stopped
+
+  # Grafana - Dashboard and alert visualization
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: diwei_dev_grafana
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    networks:
+      - diwei_dev
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   redis_data:
   minio_data:
   meilisearch_data:
   frontend_node_modules:
+  prometheus_data:
+  grafana_data:
 
 networks:
   diwei_dev:

--- a/monitoring/grafana/dashboards/api-overview.json
+++ b/monitoring/grafana/dashboards/api-overview.json
@@ -1,0 +1,55 @@
+{
+  "id": null,
+  "uid": "api-overview",
+  "title": "API Overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "tags": ["api", "fastapi"],
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Request Rate (req/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"fastapi\"}[5m]))",
+          "legendFormat": "all"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "5xx Error Rate (%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "100 * (sum(rate(http_requests_total{job=\"fastapi\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"fastapi\"}[5m])))",
+          "legendFormat": "5xx %"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "P95 Latency (s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"fastapi\"}[5m])))",
+          "legendFormat": "p95"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 }
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/db-health.json
+++ b/monitoring/grafana/dashboards/db-health.json
@@ -1,0 +1,55 @@
+{
+  "id": null,
+  "uid": "db-health",
+  "title": "DB Health",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "tags": ["database", "postgres"],
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Postgres Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "max(pg_up{job=\"postgres_exporter\"})",
+          "legendFormat": "up"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Active Connections",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(pg_stat_activity_count{job=\"postgres_exporter\"})",
+          "legendFormat": "connections"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 0 }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Database Size (bytes)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(pg_database_size_bytes{job=\"postgres_exporter\"})",
+          "legendFormat": "size"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 }
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/infrastructure-health.json
+++ b/monitoring/grafana/dashboards/infrastructure-health.json
@@ -1,0 +1,55 @@
+{
+  "id": null,
+  "uid": "infrastructure-health",
+  "title": "Infrastructure Health",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "tags": ["infrastructure", "redis", "prometheus"],
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Redis Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "max(redis_up{job=\"redis_exporter\"})",
+          "legendFormat": "redis"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 0 }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Redis Connected Clients",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "redis_connected_clients{job=\"redis_exporter\"}",
+          "legendFormat": "clients"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 0 }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Prometheus Targets Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (job) (up)",
+          "legendFormat": "{{job}}"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 }
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: DiWeiWei Dashboards
+    orgId: 1
+    folder: DiWeiWei
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -1,0 +1,29 @@
+groups:
+  - name: api-alerts
+    rules:
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(http_requests_total{job="fastapi",status=~"5.."}[5m]))
+            /
+            sum(rate(http_requests_total{job="fastapi"}[5m]))
+          ) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High API error rate"
+          description: "FastAPI 5xx error rate is above 5% for at least 2 minutes."
+
+      - alert: SlowAPI
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le) (rate(http_request_duration_seconds_bucket{job="fastapi"}[5m]))
+          ) > 1
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow API responses"
+          description: "FastAPI p95 request latency is above 1 second for at least 2 minutes."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,26 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["prometheus:9090"]
+
+  - job_name: fastapi
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["app:8000"]
+
+  - job_name: postgres_exporter
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["postgres_exporter:9187"]
+
+  - job_name: redis_exporter
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["redis_exporter:9121"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "redis>=5.0.1",
     "minio>=7.2.0",
     "meilisearch>=0.28.0",
+    "prometheus-fastapi-instrumentator>=7.1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,7 @@ def app(db_session, mock_redis, mock_minio_storage):
     from app.modules.nanos.router import get_nanos_router
     from app.modules.search.router import get_search_router
     from app.modules.upload.router import get_upload_router
+    from app.monitoring import configure_monitoring
 
     settings = get_settings()
 
@@ -192,6 +193,7 @@ def app(db_session, mock_redis, mock_minio_storage):
     app.include_router(get_upload_router())
     app.include_router(get_nanos_router())
     app.include_router(get_search_router())
+    configure_monitoring(app)
 
     # Add endpoints
     @app.get("/health")

--- a/tests/modules/auth/test_auth_routes.py
+++ b/tests/modules/auth/test_auth_routes.py
@@ -295,6 +295,16 @@ async def test_health_check_endpoint(client: TestClient):
 
 
 @pytest.mark.asyncio
+async def test_metrics_endpoint_available(client: TestClient):
+    """Test Prometheus metrics endpoint availability."""
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert "# HELP" in response.text
+
+
+@pytest.mark.asyncio
 async def test_root_endpoint(client: TestClient, monkeypatch: pytest.MonkeyPatch):
     """Test root endpoint redirects to frontend landing page"""
     monkeypatch.setenv("FRONTEND_URL", "http://localhost:5173")


### PR DESCRIPTION
## Summary

Implements the monitoring baseline for issue #70.

### What changed
- add Prometheus, Grafana, PostgreSQL exporter, and Redis exporter to the Compose stack
- expose FastAPI metrics via `/metrics` and add test coverage for the endpoint
- add Prometheus scrape configuration and baseline alert rules (`HighErrorRate`, `SlowAPI`)
- provision three Grafana dashboards for API, DB, and infrastructure health
- add monitoring setup documentation and update README
- append implementation learnings and stabilize the local `Test: Verified` readiness flow

### Validation
- `Checks` task passes
- `Test: Verified` passes end-to-end
- monitoring stack was validated locally (`docker compose pull`, `up`, target/rule/health checks, `down`)

Fixes #70