### PR TITLE
141: Implement Nano flag reporting workflow

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -45,6 +45,7 @@ Kompaktes Regelwerk für Implementierung, Review und Qualitätssicherung.
 - Öffentliche APIs nur freigegebene Inhalte zeigen; Moderations-/Pending-Reads separieren.
 - Nach Content-Updates Moderationsstatus auf `pending` zurücksetzen, Metadaten bereinigen.
 - Admin-Takedown: Dedizierte Endpoint-Semantik, idempotente Wiederholung, strukturierte Audit-Metadaten, explizite Cache-Invalidierung.
+- User-Flagging robust über drei Ebenen absichern: Service-Guard (Self-Flag 403), DB-Unique-Constraint (`nano_id`,`flagging_user_id`) + `IntegrityError`→409, und sofortige `ModerationCase`-Verknüpfung mit `reporter_id`.
 
 ### Validierung & Sicherheit
 - Query-/Enum-Parameter serverseitig validieren; ungültige Werte → sauber 4xx.

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -227,6 +227,8 @@ class AuditAction(str, enum.Enum):
     MODERATION_REJECTED = "moderation_rejected"
     MODERATION_DEFERRED = "moderation_deferred"
     MODERATION_ESCALATED = "moderation_escalated"
+    FLAG_CREATED = "flag_created"
+    FLAG_REVIEWED = "flag_reviewed"
 
 
 class FeedbackModerationStatus(str, enum.Enum):
@@ -878,6 +880,95 @@ class ModerationContentType(str, enum.Enum):
     NANO_RATING = "nano_rating"
     NANO_COMMENT = "nano_comment"
     FLAG = "flag"  # reserved: Story 6.3
+
+
+class FlagReason(str, enum.Enum):
+    """Reason selected by a user when reporting a Nano."""
+
+    SPAM = "spam"
+    COPYRIGHT = "copyright"
+    OFFENSIVE = "offensive"
+    MISINFORMATION = "misinformation"
+    OTHER = "other"
+
+
+class FlagStatus(str, enum.Enum):
+    """Lifecycle status of a user-submitted Nano flag."""
+
+    PENDING = "pending"
+    REVIEWED = "reviewed"
+    RESOLVED = "resolved"
+    CLOSED = "closed"
+
+
+class NanoFlag(Base):
+    """User-submitted flag for inappropriate or policy-violating Nano content."""
+
+    __tablename__ = "nano_flags"
+    __table_args__ = (
+        UniqueConstraint("nano_id", "flagging_user_id", name="uq_nano_flags_nano_user"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True
+    )
+    nano_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("nanos.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Flagged Nano",
+    )
+    flagging_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="User who submitted this flag",
+    )
+    reason: Mapped[FlagReason] = mapped_column(
+        SQLEnum(FlagReason),
+        nullable=False,
+        comment="Selected report reason",
+    )
+    comment: Mapped[Optional[str]] = mapped_column(
+        String(500),
+        nullable=True,
+        comment="Optional user comment (max 500 chars)",
+    )
+    status: Mapped[FlagStatus] = mapped_column(
+        SQLEnum(FlagStatus),
+        default=FlagStatus.PENDING,
+        nullable=False,
+        index=True,
+        comment="Current status of the flag workflow",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        index=True,
+        comment="When the flag was submitted",
+    )
+    reviewed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="When a moderator/admin reviewed this flag",
+    )
+    moderator_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+        comment="Moderator/admin who reviewed this flag",
+    )
+
+    def __repr__(self) -> str:
+        """String representation of NanoFlag."""
+        return (
+            f"<NanoFlag(id={self.id}, nano_id={self.nano_id}, "
+            f"flagging_user_id={self.flagging_user_id}, status={self.status})>"
+        )
 
 
 class ModerationCase(Base):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -909,9 +909,7 @@ class NanoFlag(Base):
         UniqueConstraint("nano_id", "flagging_user_id", name="uq_nano_flags_nano_user"),
     )
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True
-    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     nano_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("nanos.id", ondelete="CASCADE"),

--- a/app/modules/moderation/schemas.py
+++ b/app/modules/moderation/schemas.py
@@ -99,7 +99,18 @@ class CommentContentDetail(BaseModel):
     created_at: Optional[datetime] = None
 
 
-ContentDetail = NanoContentDetail | RatingContentDetail | CommentContentDetail
+class FlagContentDetail(BaseModel):
+    """Content detail for a user-submitted Nano flag under review."""
+
+    nano_id: UUID
+    reason: str
+    comment: Optional[str] = None
+    flag_status: str
+    flagged_by_username: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+ContentDetail = NanoContentDetail | RatingContentDetail | CommentContentDetail | FlagContentDetail
 
 
 # ---------------------------------------------------------------------------

--- a/app/modules/moderation/service.py
+++ b/app/modules/moderation/service.py
@@ -727,7 +727,9 @@ async def _apply_flag_decision(
         flag.status = FlagStatus.RESOLVED
     elif decision == "reject":
         flag.status = FlagStatus.CLOSED
-    # defer / escalate: leave flag.status as PENDING; no terminal decision reached.
+    else:
+        # Non-terminal decisions still mark the report as reviewed by moderation.
+        flag.status = FlagStatus.REVIEWED
 
     flag.reviewed_at = now
     flag.moderator_id = decided_by.user_id

--- a/app/modules/moderation/service.py
+++ b/app/modules/moderation/service.py
@@ -38,11 +38,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import (
     AuditAction,
     FeedbackModerationStatus,
+    FlagStatus,
     ModerationCase,
     ModerationCaseStatus,
     ModerationContentType,
     Nano,
     NanoComment,
+    NanoFlag,
     NanoRating,
     NanoStatus,
     User,
@@ -53,6 +55,7 @@ from app.modules.moderation.schemas import (
     VALID_DECISIONS,
     CommentContentDetail,
     ContentDetail,
+    FlagContentDetail,
     ModerationQueueItem,
     ModerationQueueResponse,
     ModerationReviewRequest,
@@ -90,6 +93,7 @@ async def upsert_moderation_case(
     db: AsyncSession,
     content_type: ModerationContentType,
     content_id: UUID,
+    reporter_id: UUID | None = None,
 ) -> ModerationCase:
     """Create or reset a moderation case to PENDING.
 
@@ -121,6 +125,7 @@ async def upsert_moderation_case(
         case = ModerationCase(
             content_type=content_type,
             content_id=content_id,
+            reporter_id=reporter_id,
             status=ModerationCaseStatus.PENDING,
         )
         db.add(case)
@@ -132,6 +137,8 @@ async def upsert_moderation_case(
         case.decided_at = None
         case.deferred_until = None
         case.escalation_note = None
+        if reporter_id is not None:
+            case.reporter_id = reporter_id
 
     await db.flush()
     return case
@@ -561,6 +568,11 @@ async def _apply_decision_to_content(
             db=db, case=case, decided_by=decided_by, request=request, now=now
         )
 
+    elif case.content_type == ModerationContentType.FLAG:
+        await _apply_flag_decision(
+            db=db, case=case, decided_by=decided_by, decision=decision, now=now
+        )
+
     # ModerationContentType.FLAG — reserved for Story 6.3; no action yet.
     return False
 
@@ -697,6 +709,33 @@ async def _apply_comment_decision(
     await db.flush()
 
 
+async def _apply_flag_decision(
+    *,
+    db: AsyncSession,
+    case: ModerationCase,
+    decided_by: TokenData,
+    decision: str,
+    now: datetime,
+) -> None:
+    """Apply moderation decision to a NanoFlag status lifecycle."""
+    stmt = select(NanoFlag).where(NanoFlag.id == case.content_id)
+    result = await db.execute(stmt)
+    flag = result.scalar_one_or_none()
+    if not flag:
+        return
+
+    if decision == "approve":
+        flag.status = FlagStatus.RESOLVED
+    elif decision == "reject":
+        flag.status = FlagStatus.CLOSED
+    else:
+        flag.status = FlagStatus.REVIEWED
+
+    flag.reviewed_at = now
+    flag.moderator_id = decided_by.user_id
+    await db.flush()
+
+
 async def _sync_nano_rating_cache(*, db: AsyncSession, nano_id: UUID) -> None:
     """Recompute and persist the denormalised average_rating / rating_count on Nano.
 
@@ -742,7 +781,7 @@ async def _get_content_detail(
     db: AsyncSession,
     content_type: ModerationContentType,
     content_id: UUID,
-) -> Optional[NanoContentDetail | RatingContentDetail | CommentContentDetail]:
+) -> Optional[NanoContentDetail | RatingContentDetail | CommentContentDetail | FlagContentDetail]:
     """Load a type-specific content detail object for a queue item.
 
     Returns ``None`` if the underlying content record no longer exists.
@@ -801,6 +840,25 @@ async def _get_content_detail(
             created_at=comment.created_at,
         )
 
+    if content_type == ModerationContentType.FLAG:
+        stmt = (
+            select(NanoFlag, User.username)
+            .outerjoin(User, NanoFlag.flagging_user_id == User.id)
+            .where(NanoFlag.id == content_id)
+        )
+        row = (await db.execute(stmt)).first()
+        if not row:
+            return None
+        flag, username = row
+        return FlagContentDetail(
+            nano_id=flag.nano_id,
+            reason=flag.reason.value,
+            comment=flag.comment,
+            flag_status=flag.status.value,
+            flagged_by_username=username,
+            created_at=flag.created_at,
+        )
+
     return None
 
 
@@ -822,6 +880,9 @@ async def _load_content_details_for_cases(
     ]
     comment_ids = [
         case.content_id for case in cases if case.content_type == ModerationContentType.NANO_COMMENT
+    ]
+    flag_ids = [
+        case.content_id for case in cases if case.content_type == ModerationContentType.FLAG
     ]
 
     if nano_ids:
@@ -873,6 +934,24 @@ async def _load_content_details_for_cases(
                 author_username=username,
                 moderation_status=comment.moderation_status.value,
                 created_at=comment.created_at,
+            )
+
+    if flag_ids:
+        rows = (
+            await db.execute(
+                select(NanoFlag, User.username)
+                .outerjoin(User, NanoFlag.flagging_user_id == User.id)
+                .where(NanoFlag.id.in_(flag_ids))
+            )
+        ).all()
+        for flag, username in rows:
+            detail_map[(ModerationContentType.FLAG, flag.id)] = FlagContentDetail(
+                nano_id=flag.nano_id,
+                reason=flag.reason.value,
+                comment=flag.comment,
+                flag_status=flag.status.value,
+                flagged_by_username=username,
+                created_at=flag.created_at,
             )
 
     for case in cases:

--- a/app/modules/moderation/service.py
+++ b/app/modules/moderation/service.py
@@ -573,7 +573,6 @@ async def _apply_decision_to_content(
             db=db, case=case, decided_by=decided_by, decision=decision, now=now
         )
 
-    # ModerationContentType.FLAG — reserved for Story 6.3; no action yet.
     return False
 
 
@@ -728,8 +727,7 @@ async def _apply_flag_decision(
         flag.status = FlagStatus.RESOLVED
     elif decision == "reject":
         flag.status = FlagStatus.CLOSED
-    else:
-        flag.status = FlagStatus.REVIEWED
+    # defer / escalate: leave flag.status as PENDING; no terminal decision reached.
 
     flag.reviewed_at = now
     flag.moderator_id = decided_by.user_id

--- a/app/modules/nanos/router.py
+++ b/app/modules/nanos/router.py
@@ -39,6 +39,8 @@ from app.modules.nanos.schemas import (
     NanoDeleteResponse,
     NanoDetailResponse,
     NanoDownloadInfoResponse,
+    NanoFlagCreateRequest,
+    NanoFlagResponse,
     NanoMetadataResponse,
     NanoRatingModerationResponse,
     NanoRatingMutationResponse,
@@ -50,9 +52,11 @@ from app.modules.nanos.schemas import (
 from app.modules.nanos.service import (
     admin_takedown_nano,
     create_nano_comment,
+    create_nano_flag,
     create_nano_rating,
     delete_nano,
     get_creator_nanos,
+    get_my_nano_flag,
     get_nano_comments,
     get_nano_detail,
     get_nano_download_info,
@@ -498,6 +502,66 @@ def get_nanos_router(prefix: str = "/api/v1/nanos", tags: list[str] | None = Non
     ) -> NanoCommentListResponse:
         """List comments for a published Nano with deterministic pagination."""
         return await get_nano_comments(nano_id=nano_id, db=db, page=page, limit=limit)
+
+    @router.post(
+        "/{nano_id}/flags",
+        response_model=NanoFlagResponse,
+        status_code=status.HTTP_201_CREATED,
+        summary="Create a Nano flag/report",
+        description="""
+        Submit a user report (flag) for a published Nano.
+
+        **Rules:**
+        - Authentication required
+        - Creator cannot flag their own Nano
+        - One flag per user per Nano
+
+        **Error Cases:**
+        - 400: Nano is not published
+        - 401: Not authenticated
+        - 403: Creator attempted to flag own Nano
+        - 404: Nano not found
+        - 409: User already flagged this Nano
+        """,
+    )
+    async def create_nano_flag_endpoint(
+        nano_id: UUID,
+        payload: NanoFlagCreateRequest,
+        current_user: Annotated[TokenData, Depends(get_current_user)],
+        db: Annotated[AsyncSession, Depends(get_db)],
+    ) -> NanoFlagResponse:
+        """Create a new user flag for one Nano."""
+        return await create_nano_flag(
+            nano_id=nano_id,
+            payload=payload,
+            current_user=current_user,
+            db=db,
+        )
+
+    @router.get(
+        "/{nano_id}/flags/my-flag",
+        response_model=NanoFlagResponse,
+        status_code=status.HTTP_200_OK,
+        summary="Get my flag for a Nano",
+        description="""
+        Retrieve the authenticated user's existing flag for one Nano.
+
+        **Error Cases:**
+        - 401: Not authenticated
+        - 404: Nano not found or user has not flagged this Nano
+        """,
+    )
+    async def get_my_nano_flag_endpoint(
+        nano_id: UUID,
+        current_user: Annotated[TokenData, Depends(get_current_user)],
+        db: Annotated[AsyncSession, Depends(get_db)],
+    ) -> NanoFlagResponse:
+        """Return the caller's flag resource for this Nano."""
+        return await get_my_nano_flag(
+            nano_id=nano_id,
+            current_user=current_user,
+            db=db,
+        )
 
     @router.post(
         "/{nano_id}/comments",

--- a/app/modules/nanos/schemas.py
+++ b/app/modules/nanos/schemas.py
@@ -11,6 +11,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.models import FlagReason, FlagStatus
+
 
 class MetadataUpdateRequest(BaseModel):
     """
@@ -291,6 +293,42 @@ class NanoCommentUpsertRequest(BaseModel):
         if not value.strip():
             raise ValueError("content must not be empty")
         return value
+
+
+class NanoFlagCreateRequest(BaseModel):
+    """Request payload for creating a user report (flag) on a Nano."""
+
+    reason: FlagReason = Field(..., description="Reason code for the report")
+    comment: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Optional additional context (max 500 chars)",
+    )
+
+    @field_validator("comment")
+    @classmethod
+    def validate_comment(cls, value: Optional[str]) -> Optional[str]:
+        """Normalize empty comments to None and trim surrounding whitespace."""
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            return None
+        return normalized
+
+
+class NanoFlagResponse(BaseModel):
+    """Response payload for Nano flag resources."""
+
+    id: UUID = Field(..., description="Unique identifier of the flag")
+    nano_id: UUID = Field(..., description="Flagged Nano identifier")
+    flagging_user_id: UUID = Field(..., description="User who submitted the flag")
+    reason: FlagReason = Field(..., description="Selected report reason")
+    comment: Optional[str] = Field(None, description="Optional user comment")
+    status: FlagStatus = Field(..., description="Flag workflow status")
+    created_at: datetime = Field(..., description="Submission timestamp")
+    reviewed_at: Optional[datetime] = Field(None, description="Review timestamp, if reviewed")
+    moderator_id: Optional[UUID] = Field(None, description="Reviewer user ID")
 
 
 class NanoCommentItem(BaseModel):

--- a/app/modules/nanos/service.py
+++ b/app/modules/nanos/service.py
@@ -21,11 +21,13 @@ from app.models import (
     Category,
     CompetencyLevel,
     FeedbackModerationStatus,
+    FlagStatus,
     LicenseType,
     ModerationContentType,
     Nano,
     NanoCategoryAssignment,
     NanoComment,
+    NanoFlag,
     NanoFormat,
     NanoRating,
     NanoStatus,
@@ -59,6 +61,8 @@ from app.modules.nanos.schemas import (
     NanoDownloadInfo,
     NanoDownloadInfoData,
     NanoDownloadInfoResponse,
+    NanoFlagCreateRequest,
+    NanoFlagResponse,
     NanoMetadataResponse,
     NanoRatingAggregation,
     NanoRatingDistributionItem,
@@ -701,6 +705,21 @@ async def _build_comment_item(comment: NanoComment, db: AsyncSession) -> NanoCom
     )
 
 
+def _build_flag_response(flag: NanoFlag) -> NanoFlagResponse:
+    """Map a NanoFlag ORM object to API response schema."""
+    return NanoFlagResponse(
+        id=flag.id,
+        nano_id=flag.nano_id,
+        flagging_user_id=flag.flagging_user_id,
+        reason=flag.reason,
+        comment=flag.comment,
+        status=flag.status,
+        created_at=flag.created_at,
+        reviewed_at=flag.reviewed_at,
+        moderator_id=flag.moderator_id,
+    )
+
+
 async def _build_rating_item(rating: NanoRating, db: AsyncSession) -> NanoRatingModerationItem:
     """Build API rating item with author context."""
     user_stmt = select(User.username).where(User.id == rating.user_id)
@@ -837,6 +856,91 @@ async def create_nano_comment(
         ) from exc
 
     return NanoCommentMutationResponse(comment=await _build_comment_item(comment=comment, db=db))
+
+
+async def create_nano_flag(
+    nano_id: UUID,
+    payload: NanoFlagCreateRequest,
+    current_user: TokenData,
+    db: AsyncSession,
+) -> NanoFlagResponse:
+    """Create a user flag for a published Nano and open/update moderation case."""
+    nano = await _get_nano_or_404(nano_id=nano_id, db=db)
+
+    if nano.status != NanoStatus.PUBLISHED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Flags can only be submitted for published Nanos",
+        )
+
+    if nano.creator_id == current_user.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot flag your own Nanos",
+        )
+
+    flag = NanoFlag(
+        nano_id=nano_id,
+        flagging_user_id=current_user.user_id,
+        reason=payload.reason,
+        comment=payload.comment,
+        status=FlagStatus.PENDING,
+    )
+    db.add(flag)
+
+    try:
+        await db.flush()
+        await upsert_moderation_case(
+            db=db,
+            content_type=ModerationContentType.FLAG,
+            content_id=flag.id,
+            reporter_id=current_user.user_id,
+        )
+        await AuditLogger.log_action(
+            session=db,
+            action=AuditAction.FLAG_CREATED,
+            user_id=current_user.user_id,
+            resource_type="nano_flag",
+            resource_id=str(flag.id),
+            metadata={
+                "nano_id": str(nano_id),
+                "reason": payload.reason.value,
+            },
+        )
+        await db.commit()
+        await db.refresh(flag)
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="You have already flagged this Nano",
+        ) from exc
+
+    return _build_flag_response(flag)
+
+
+async def get_my_nano_flag(
+    nano_id: UUID,
+    current_user: TokenData,
+    db: AsyncSession,
+) -> NanoFlagResponse:
+    """Return the authenticated user's existing flag for a Nano."""
+    await _get_nano_or_404(nano_id=nano_id, db=db)
+
+    stmt = select(NanoFlag).where(
+        NanoFlag.nano_id == nano_id,
+        NanoFlag.flagging_user_id == current_user.user_id,
+    )
+    result = await db.execute(stmt)
+    flag = result.scalar_one_or_none()
+
+    if flag is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Flag not found for this Nano and user",
+        )
+
+    return _build_flag_response(flag)
 
 
 async def update_nano_comment(

--- a/app/modules/nanos/service.py
+++ b/app/modules/nanos/service.py
@@ -5,6 +5,7 @@ This module provides service functions for creating, reading, and updating
 Nano metadata with proper validation and authorization checks.
 """
 
+import logging
 from datetime import datetime, timezone
 from decimal import ROUND_HALF_UP, Decimal
 from html import escape
@@ -12,7 +13,7 @@ from uuid import UUID
 
 from fastapi import HTTPException, status
 from sqlalchemy import desc, func, select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -78,6 +79,8 @@ from app.modules.nanos.schemas import (
 )
 from app.modules.search.service import invalidate_search_cache
 from app.modules.upload.storage import StorageError, get_storage_adapter
+
+logger = logging.getLogger(__name__)
 
 MAX_COMMENT_LENGTH = 1000
 
@@ -879,11 +882,17 @@ async def create_nano_flag(
             detail="You cannot flag your own Nanos",
         )
 
+    sanitized_comment = (
+        _sanitize_comment_content(payload.comment) if payload.comment is not None else None
+    )
+    if sanitized_comment is not None:
+        _validate_sanitized_comment_content(sanitized_comment)
+
     flag = NanoFlag(
         nano_id=nano_id,
         flagging_user_id=current_user.user_id,
         reason=payload.reason,
-        comment=payload.comment,
+        comment=sanitized_comment,
         status=FlagStatus.PENDING,
     )
     db.add(flag)
@@ -896,17 +905,29 @@ async def create_nano_flag(
             content_id=flag.id,
             reporter_id=current_user.user_id,
         )
-        await AuditLogger.log_action(
-            session=db,
-            action=AuditAction.FLAG_CREATED,
-            user_id=current_user.user_id,
-            resource_type="nano_flag",
-            resource_id=str(flag.id),
-            metadata={
-                "nano_id": str(nano_id),
-                "reason": payload.reason.value,
-            },
-        )
+        try:
+            async with db.begin_nested():
+                await AuditLogger.log_action(
+                    session=db,
+                    action=AuditAction.FLAG_CREATED,
+                    user_id=current_user.user_id,
+                    resource_type="nano_flag",
+                    resource_id=str(flag.id),
+                    metadata={
+                        "nano_id": str(nano_id),
+                        "reason": payload.reason.value,
+                    },
+                )
+        except SQLAlchemyError:
+            logger.exception(
+                "Failed to persist flag-created audit event; continuing flag workflow",
+                extra={
+                    "nano_id": str(nano_id),
+                    "flag_id": str(flag.id),
+                    "user_id": str(current_user.user_id),
+                },
+            )
+
         await db.commit()
         await db.refresh(flag)
     except IntegrityError as exc:

--- a/migrations/versions/e8a1d7f4c2b9_add_nano_flags_table.py
+++ b/migrations/versions/e8a1d7f4c2b9_add_nano_flags_table.py
@@ -1,0 +1,132 @@
+"""Add nano_flags table and audit actions for Story 6.3 flagging
+
+Revision ID: e8a1d7f4c2b9
+Revises: c7f4d2a9b6e1
+Create Date: 2026-04-13 10:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e8a1d7f4c2b9"
+down_revision: Union[str, Sequence[str], None] = "c7f4d2a9b6e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_ENUM_FLAG_REASON = "flagreason"
+_ENUM_FLAG_STATUS = "flagstatus"
+
+
+def upgrade() -> None:
+    """Create nano_flags table and extend auditaction enum for flag lifecycle."""
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'FLAG_CREATED'")
+    op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'FLAG_REVIEWED'")
+
+    flag_reason = sa.Enum(
+        "SPAM",
+        "COPYRIGHT",
+        "OFFENSIVE",
+        "MISINFORMATION",
+        "OTHER",
+        name=_ENUM_FLAG_REASON,
+    )
+    flag_status = sa.Enum(
+        "PENDING",
+        "REVIEWED",
+        "RESOLVED",
+        "CLOSED",
+        name=_ENUM_FLAG_STATUS,
+    )
+    flag_reason.create(op.get_bind(), checkfirst=True)
+    flag_status.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "nano_flags",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("nano_id", sa.UUID(), nullable=False, comment="Flagged Nano"),
+        sa.Column("flagging_user_id", sa.UUID(), nullable=False, comment="User who submitted this flag"),
+        sa.Column(
+            "reason",
+            sa.Enum(
+                "SPAM",
+                "COPYRIGHT",
+                "OFFENSIVE",
+                "MISINFORMATION",
+                "OTHER",
+                name=_ENUM_FLAG_REASON,
+                create_type=False,
+            ),
+            nullable=False,
+            comment="Selected report reason",
+        ),
+        sa.Column("comment", sa.String(length=500), nullable=True, comment="Optional user comment (max 500 chars)"),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "PENDING",
+                "REVIEWED",
+                "RESOLVED",
+                "CLOSED",
+                name=_ENUM_FLAG_STATUS,
+                create_type=False,
+            ),
+            nullable=False,
+            server_default=sa.text("'PENDING'"),
+            comment="Current status of the flag workflow",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+            comment="When the flag was submitted",
+        ),
+        sa.Column(
+            "reviewed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="When a moderator/admin reviewed this flag",
+        ),
+        sa.Column(
+            "moderator_id",
+            sa.UUID(),
+            nullable=True,
+            comment="Moderator/admin who reviewed this flag",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("nano_id", "flagging_user_id", name="uq_nano_flags_nano_user"),
+        sa.ForeignKeyConstraint(["nano_id"], ["nanos.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["flagging_user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["moderator_id"], ["users.id"], ondelete="SET NULL"),
+    )
+
+    op.create_index(op.f("ix_nano_flags_id"), "nano_flags", ["id"], unique=False)
+    op.create_index(op.f("ix_nano_flags_nano_id"), "nano_flags", ["nano_id"], unique=False)
+    op.create_index(
+        op.f("ix_nano_flags_flagging_user_id"), "nano_flags", ["flagging_user_id"], unique=False
+    )
+    op.create_index(op.f("ix_nano_flags_status"), "nano_flags", ["status"], unique=False)
+    op.create_index(op.f("ix_nano_flags_created_at"), "nano_flags", ["created_at"], unique=False)
+    op.create_index(op.f("ix_nano_flags_moderator_id"), "nano_flags", ["moderator_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Drop nano_flags table and enum types.
+
+    Note: auditaction enum values are intentionally retained because PostgreSQL
+    cannot safely drop individual enum values without recreating dependent types.
+    """
+    op.drop_index(op.f("ix_nano_flags_moderator_id"), table_name="nano_flags")
+    op.drop_index(op.f("ix_nano_flags_created_at"), table_name="nano_flags")
+    op.drop_index(op.f("ix_nano_flags_status"), table_name="nano_flags")
+    op.drop_index(op.f("ix_nano_flags_flagging_user_id"), table_name="nano_flags")
+    op.drop_index(op.f("ix_nano_flags_nano_id"), table_name="nano_flags")
+    op.drop_index(op.f("ix_nano_flags_id"), table_name="nano_flags")
+    op.drop_table("nano_flags")
+
+    sa.Enum(name=_ENUM_FLAG_STATUS).drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name=_ENUM_FLAG_REASON).drop(op.get_bind(), checkfirst=True)

--- a/migrations/versions/e8a1d7f4c2b9_add_nano_flags_table.py
+++ b/migrations/versions/e8a1d7f4c2b9_add_nano_flags_table.py
@@ -27,18 +27,18 @@ def upgrade() -> None:
     op.execute("ALTER TYPE auditaction ADD VALUE IF NOT EXISTS 'FLAG_REVIEWED'")
 
     flag_reason = sa.Enum(
-        "SPAM",
-        "COPYRIGHT",
-        "OFFENSIVE",
-        "MISINFORMATION",
-        "OTHER",
+        "spam",
+        "copyright",
+        "offensive",
+        "misinformation",
+        "other",
         name=_ENUM_FLAG_REASON,
     )
     flag_status = sa.Enum(
-        "PENDING",
-        "REVIEWED",
-        "RESOLVED",
-        "CLOSED",
+        "pending",
+        "reviewed",
+        "resolved",
+        "closed",
         name=_ENUM_FLAG_STATUS,
     )
     flag_reason.create(op.get_bind(), checkfirst=True)
@@ -48,34 +48,41 @@ def upgrade() -> None:
         "nano_flags",
         sa.Column("id", sa.UUID(), nullable=False),
         sa.Column("nano_id", sa.UUID(), nullable=False, comment="Flagged Nano"),
-        sa.Column("flagging_user_id", sa.UUID(), nullable=False, comment="User who submitted this flag"),
+        sa.Column(
+            "flagging_user_id", sa.UUID(), nullable=False, comment="User who submitted this flag"
+        ),
         sa.Column(
             "reason",
             sa.Enum(
-                "SPAM",
-                "COPYRIGHT",
-                "OFFENSIVE",
-                "MISINFORMATION",
-                "OTHER",
+                "spam",
+                "copyright",
+                "offensive",
+                "misinformation",
+                "other",
                 name=_ENUM_FLAG_REASON,
                 create_type=False,
             ),
             nullable=False,
             comment="Selected report reason",
         ),
-        sa.Column("comment", sa.String(length=500), nullable=True, comment="Optional user comment (max 500 chars)"),
+        sa.Column(
+            "comment",
+            sa.String(length=500),
+            nullable=True,
+            comment="Optional user comment (max 500 chars)",
+        ),
         sa.Column(
             "status",
             sa.Enum(
-                "PENDING",
-                "REVIEWED",
-                "RESOLVED",
-                "CLOSED",
+                "pending",
+                "reviewed",
+                "resolved",
+                "closed",
                 name=_ENUM_FLAG_STATUS,
                 create_type=False,
             ),
             nullable=False,
-            server_default=sa.text("'PENDING'"),
+            server_default=sa.text("'pending'"),
             comment="Current status of the flag workflow",
         ),
         sa.Column(
@@ -104,14 +111,15 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["moderator_id"], ["users.id"], ondelete="SET NULL"),
     )
 
-    op.create_index(op.f("ix_nano_flags_id"), "nano_flags", ["id"], unique=False)
     op.create_index(op.f("ix_nano_flags_nano_id"), "nano_flags", ["nano_id"], unique=False)
     op.create_index(
         op.f("ix_nano_flags_flagging_user_id"), "nano_flags", ["flagging_user_id"], unique=False
     )
     op.create_index(op.f("ix_nano_flags_status"), "nano_flags", ["status"], unique=False)
     op.create_index(op.f("ix_nano_flags_created_at"), "nano_flags", ["created_at"], unique=False)
-    op.create_index(op.f("ix_nano_flags_moderator_id"), "nano_flags", ["moderator_id"], unique=False)
+    op.create_index(
+        op.f("ix_nano_flags_moderator_id"), "nano_flags", ["moderator_id"], unique=False
+    )
 
 
 def downgrade() -> None:
@@ -125,7 +133,6 @@ def downgrade() -> None:
     op.drop_index(op.f("ix_nano_flags_status"), table_name="nano_flags")
     op.drop_index(op.f("ix_nano_flags_flagging_user_id"), table_name="nano_flags")
     op.drop_index(op.f("ix_nano_flags_nano_id"), table_name="nano_flags")
-    op.drop_index(op.f("ix_nano_flags_id"), table_name="nano_flags")
     op.drop_table("nano_flags")
 
     sa.Enum(name=_ENUM_FLAG_STATUS).drop(op.get_bind(), checkfirst=True)

--- a/tests/modules/moderation/test_moderation_queue.py
+++ b/tests/modules/moderation/test_moderation_queue.py
@@ -22,12 +22,15 @@ from app.models import (
     AuditLog,
     CompetencyLevel,
     FeedbackModerationStatus,
+    FlagReason,
+    FlagStatus,
     LicenseType,
     ModerationCase,
     ModerationCaseStatus,
     ModerationContentType,
     Nano,
     NanoComment,
+    NanoFlag,
     NanoFormat,
     NanoRating,
     NanoStatus,
@@ -588,6 +591,74 @@ async def test_review_escalate_sets_case_note_without_changing_comment(
     assert comment.moderation_status == FeedbackModerationStatus.PENDING
     assert case.status == ModerationCaseStatus.ESCALATED
     assert case.escalation_note == "Needs legal review."
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("decision", "expected_flag_status", "expected_case_status"),
+    [
+        ("approve", FlagStatus.RESOLVED, ModerationCaseStatus.APPROVED),
+        ("reject", FlagStatus.CLOSED, ModerationCaseStatus.REJECTED),
+        ("defer", FlagStatus.REVIEWED, ModerationCaseStatus.DEFERRED),
+        ("escalate", FlagStatus.REVIEWED, ModerationCaseStatus.ESCALATED),
+    ],
+)
+async def test_review_flag_updates_flag_lifecycle_fields(
+    async_client,
+    db_session,
+    creator_user,
+    moderator_user,
+    moderator_token,
+    decision,
+    expected_flag_status,
+    expected_case_status,
+):
+    """FLAG decisions should update NanoFlag status and reviewer metadata."""
+    nano = _make_nano(
+        creator_id=creator_user.id,
+        status=NanoStatus.PUBLISHED,
+        title=f"Flag Moderation Nano {decision}",
+    )
+    db_session.add(nano)
+    await db_session.flush()
+
+    flag = NanoFlag(
+        id=uuid.uuid4(),
+        nano_id=nano.id,
+        flagging_user_id=creator_user.id,
+        reason=FlagReason.SPAM,
+        comment="Needs review",
+        status=FlagStatus.PENDING,
+    )
+    db_session.add(flag)
+    await db_session.flush()
+
+    case = ModerationCase(
+        content_type=ModerationContentType.FLAG,
+        content_id=flag.id,
+        status=ModerationCaseStatus.PENDING,
+    )
+    db_session.add(case)
+    await db_session.commit()
+
+    payload = {"decision": decision, "reason": f"Decision {decision}"}
+    if decision == "defer":
+        payload["deferred_until"] = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+
+    review = await async_client.post(
+        f"/api/v1/moderation/cases/{case.id}/review",
+        json=payload,
+        headers={"Authorization": f"Bearer {moderator_token}"},
+    )
+    assert review.status_code == 200
+
+    await db_session.refresh(flag)
+    await db_session.refresh(case)
+
+    assert flag.status == expected_flag_status
+    assert flag.reviewed_at is not None
+    assert flag.moderator_id == moderator_user.id
+    assert case.status == expected_case_status
 
 
 @pytest.mark.asyncio

--- a/tests/modules/nanos/test_flags_routes.py
+++ b/tests/modules/nanos/test_flags_routes.py
@@ -189,7 +189,84 @@ async def test_create_flag_forbidden_for_own_nano(async_client, db_session):
 
 
 @pytest.mark.asyncio
-async def test_get_my_flag_returns_404_then_resource(async_client, db_session):
+async def test_create_flag_unauthenticated_returns_401(async_client, db_session):
+    """POST to flag endpoint without an auth token must return 401."""
+    # Use a random UUID — should be rejected before any DB lookup.
+    response = await async_client.post(
+        f"/api/v1/nanos/{uuid.uuid4()}/flags",
+        json={"reason": "spam"},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_my_flag_unauthenticated_returns_401(async_client, db_session):
+    """GET my-flag endpoint without an auth token must return 401."""
+    response = await async_client.get(
+        f"/api/v1/nanos/{uuid.uuid4()}/flags/my-flag",
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_flag_nonexistent_nano_returns_404(async_client, db_session):
+    """Flagging a nano that does not exist must return 404."""
+    reporter = await _create_user(
+        db_session,
+        email="flag-404-reporter@example.com",
+        username="flag_404_reporter",
+        role=UserRole.CONSUMER,
+    )
+    await db_session.commit()
+
+    token, _ = create_access_token(reporter.id, reporter.email, role=reporter.role.value)
+    response = await async_client.post(
+        f"/api/v1/nanos/{uuid.uuid4()}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "spam"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_flag_non_published_nano_returns_400(async_client, db_session):
+    """Flagging a Nano that is not published must return 400."""
+    creator = await _create_user(
+        db_session,
+        email="flag-draft-creator@example.com",
+        username="flag_draft_creator",
+        role=UserRole.CREATOR,
+    )
+    reporter = await _create_user(
+        db_session,
+        email="flag-draft-reporter@example.com",
+        username="flag_draft_reporter",
+        role=UserRole.CONSUMER,
+    )
+
+    # Create a nano in DRAFT status — flagging should be rejected.
+    nano = Nano(
+        id=uuid.uuid4(),
+        creator_id=creator.id,
+        title="Draft Nano",
+        duration_minutes=10,
+        competency_level=CompetencyLevel.BASIC,
+        language="en",
+        format=NanoFormat.TEXT,
+        status=NanoStatus.DRAFT,
+        version="1.0.0",
+        license=LicenseType.CC_BY,
+    )
+    db_session.add(nano)
+    await db_session.commit()
+
+    token, _ = create_access_token(reporter.id, reporter.email, role=reporter.role.value)
+    response = await async_client.post(
+        f"/api/v1/nanos/{nano.id}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "spam"},
+    )
+    assert response.status_code == 400
     """My-flag endpoint returns 404 before creation and returns the flag afterwards."""
     creator = await _create_user(
         db_session,

--- a/tests/modules/nanos/test_flags_routes.py
+++ b/tests/modules/nanos/test_flags_routes.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.models import (
     CompetencyLevel,
@@ -19,6 +20,7 @@ from app.models import (
     UserStatus,
 )
 from app.modules.auth.tokens import create_access_token
+from app.modules.nanos import service as nanos_service
 
 
 async def _create_user(db_session, *, email: str, username: str, role: UserRole) -> User:
@@ -321,3 +323,102 @@ async def test_create_flag_non_published_nano_returns_400(async_client, db_sessi
     assert payload["nano_id"] == str(nano.id)
     assert payload["flagging_user_id"] == str(reporter.id)
     assert payload["reason"] == "other"
+
+
+@pytest.mark.asyncio
+async def test_create_flag_sanitizes_comment_content(async_client, db_session):
+    """Flag comments should be normalized and escaped before persistence."""
+    creator = await _create_user(
+        db_session,
+        email="flag-sanitize-creator@example.com",
+        username="flag_sanitize_creator",
+        role=UserRole.CREATOR,
+    )
+    reporter = await _create_user(
+        db_session,
+        email="flag-sanitize-reporter@example.com",
+        username="flag_sanitize_reporter",
+        role=UserRole.CONSUMER,
+    )
+
+    nano = Nano(
+        id=uuid.uuid4(),
+        creator_id=creator.id,
+        title="Sanitize Flag Nano",
+        duration_minutes=11,
+        competency_level=CompetencyLevel.BASIC,
+        language="en",
+        format=NanoFormat.TEXT,
+        status=NanoStatus.PUBLISHED,
+        version="1.0.0",
+        license=LicenseType.CC_BY,
+    )
+    db_session.add(nano)
+    await db_session.commit()
+
+    token, _ = create_access_token(reporter.id, reporter.email, role=reporter.role.value)
+    response = await async_client.post(
+        f"/api/v1/nanos/{nano.id}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "other", "comment": "  <script>alert('x')</script>\r\nline2  "},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["comment"] == "&lt;script&gt;alert('x')&lt;/script&gt;\nline2"
+
+
+@pytest.mark.asyncio
+async def test_create_flag_succeeds_when_audit_logging_fails(
+    async_client,
+    db_session,
+    monkeypatch,
+):
+    """Flag creation should succeed even when audit logging raises SQLAlchemyError."""
+    creator = await _create_user(
+        db_session,
+        email="flag-audit-fail-creator@example.com",
+        username="flag_audit_fail_creator",
+        role=UserRole.CREATOR,
+    )
+    reporter = await _create_user(
+        db_session,
+        email="flag-audit-fail-reporter@example.com",
+        username="flag_audit_fail_reporter",
+        role=UserRole.CONSUMER,
+    )
+
+    nano = Nano(
+        id=uuid.uuid4(),
+        creator_id=creator.id,
+        title="Audit Failure Flag Nano",
+        duration_minutes=16,
+        competency_level=CompetencyLevel.INTERMEDIATE,
+        language="en",
+        format=NanoFormat.VIDEO,
+        status=NanoStatus.PUBLISHED,
+        version="1.0.0",
+        license=LicenseType.CC_BY,
+    )
+    db_session.add(nano)
+    await db_session.commit()
+
+    async def _raise_audit_error(*args, **kwargs):
+        raise SQLAlchemyError("simulated audit enum mismatch")
+
+    monkeypatch.setattr(nanos_service.AuditLogger, "log_action", _raise_audit_error)
+
+    token, _ = create_access_token(reporter.id, reporter.email, role=reporter.role.value)
+    response = await async_client.post(
+        f"/api/v1/nanos/{nano.id}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "spam", "comment": "still should persist"},
+    )
+
+    assert response.status_code == 201
+
+    flag_id = uuid.UUID(response.json()["id"])
+    persisted = (
+        await db_session.execute(select(NanoFlag).where(NanoFlag.id == flag_id))
+    ).scalar_one_or_none()
+    assert persisted is not None

--- a/tests/modules/nanos/test_flags_routes.py
+++ b/tests/modules/nanos/test_flags_routes.py
@@ -1,0 +1,246 @@
+"""Tests for Nano flag routes (Story 6.3 user reporting)."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.models import (
+    CompetencyLevel,
+    LicenseType,
+    ModerationCase,
+    ModerationContentType,
+    Nano,
+    NanoFlag,
+    NanoFormat,
+    NanoStatus,
+    User,
+    UserRole,
+    UserStatus,
+)
+from app.modules.auth.tokens import create_access_token
+
+
+async def _create_user(db_session, *, email: str, username: str, role: UserRole) -> User:
+    """Create and flush a user for route tests."""
+    user = User(
+        id=uuid.uuid4(),
+        email=email,
+        username=username,
+        password_hash="dummy_hash",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        role=role,
+        preferred_language="en",
+        login_attempts=0,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest.mark.asyncio
+async def test_create_flag_success_creates_moderation_case(async_client, db_session):
+    """Submitting a flag creates a nano_flag row and moderation case with reporter."""
+    creator = await _create_user(
+        db_session,
+        email="flag-creator@example.com",
+        username="flag_creator",
+        role=UserRole.CREATOR,
+    )
+    reporter = await _create_user(
+        db_session,
+        email="flag-reporter@example.com",
+        username="flag_reporter",
+        role=UserRole.CONSUMER,
+    )
+
+    nano = Nano(
+        id=uuid.uuid4(),
+        creator_id=creator.id,
+        title="Flaggable Nano",
+        duration_minutes=15,
+        competency_level=CompetencyLevel.BASIC,
+        language="en",
+        format=NanoFormat.TEXT,
+        status=NanoStatus.PUBLISHED,
+        version="1.0.0",
+        license=LicenseType.CC_BY,
+    )
+    db_session.add(nano)
+    await db_session.commit()
+
+    token, _ = create_access_token(reporter.id, reporter.email, role=reporter.role.value)
+    response = await async_client.post(
+        f"/api/v1/nanos/{nano.id}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "spam", "comment": "Looks like ad spam."},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["nano_id"] == str(nano.id)
+    assert payload["flagging_user_id"] == str(reporter.id)
+    assert payload["reason"] == "spam"
+    assert payload["status"] == "pending"
+
+    flag_id = uuid.UUID(payload["id"])
+
+    flag = (
+        await db_session.execute(select(NanoFlag).where(NanoFlag.id == flag_id))
+    ).scalar_one_or_none()
+    assert flag is not None
+
+    case = (
+        await db_session.execute(
+            select(ModerationCase).where(
+                ModerationCase.content_type == ModerationContentType.FLAG,
+                ModerationCase.content_id == flag_id,
+            )
+        )
+    ).scalar_one_or_none()
+    assert case is not None
+    assert case.reporter_id == reporter.id
+
+
+@pytest.mark.asyncio
+async def test_create_flag_duplicate_returns_409(async_client, db_session):
+    """The same user cannot flag the same nano more than once."""
+    creator = await _create_user(
+        db_session,
+        email="flag-dup-creator@example.com",
+        username="flag_dup_creator",
+        role=UserRole.CREATOR,
+    )
+    reporter = await _create_user(
+        db_session,
+        email="flag-dup-reporter@example.com",
+        username="flag_dup_reporter",
+        role=UserRole.CONSUMER,
+    )
+
+    nano = Nano(
+        id=uuid.uuid4(),
+        creator_id=creator.id,
+        title="Duplicate Flag Nano",
+        duration_minutes=20,
+        competency_level=CompetencyLevel.INTERMEDIATE,
+        language="en",
+        format=NanoFormat.VIDEO,
+        status=NanoStatus.PUBLISHED,
+        version="1.0.0",
+        license=LicenseType.CC_BY,
+    )
+    db_session.add(nano)
+    await db_session.commit()
+
+    token, _ = create_access_token(reporter.id, reporter.email, role=reporter.role.value)
+
+    first = await async_client.post(
+        f"/api/v1/nanos/{nano.id}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "offensive", "comment": "First report"},
+    )
+    second = await async_client.post(
+        f"/api/v1/nanos/{nano.id}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "spam", "comment": "Second report"},
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 409
+    assert "already flagged" in second.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_create_flag_forbidden_for_own_nano(async_client, db_session):
+    """Creators cannot flag their own nanos."""
+    creator = await _create_user(
+        db_session,
+        email="flag-owner@example.com",
+        username="flag_owner",
+        role=UserRole.CREATOR,
+    )
+
+    nano = Nano(
+        id=uuid.uuid4(),
+        creator_id=creator.id,
+        title="Owned Nano",
+        duration_minutes=10,
+        competency_level=CompetencyLevel.BASIC,
+        language="de",
+        format=NanoFormat.MIXED,
+        status=NanoStatus.PUBLISHED,
+        version="1.0.0",
+        license=LicenseType.CC_BY,
+    )
+    db_session.add(nano)
+    await db_session.commit()
+
+    token, _ = create_access_token(creator.id, creator.email, role=creator.role.value)
+    response = await async_client.post(
+        f"/api/v1/nanos/{nano.id}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "misinformation", "comment": "Should fail"},
+    )
+
+    assert response.status_code == 403
+    assert "cannot flag your own nanos" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_my_flag_returns_404_then_resource(async_client, db_session):
+    """My-flag endpoint returns 404 before creation and returns the flag afterwards."""
+    creator = await _create_user(
+        db_session,
+        email="flag-my-creator@example.com",
+        username="flag_my_creator",
+        role=UserRole.CREATOR,
+    )
+    reporter = await _create_user(
+        db_session,
+        email="flag-my-reporter@example.com",
+        username="flag_my_reporter",
+        role=UserRole.CONSUMER,
+    )
+
+    nano = Nano(
+        id=uuid.uuid4(),
+        creator_id=creator.id,
+        title="Lookup Flag Nano",
+        duration_minutes=12,
+        competency_level=CompetencyLevel.BASIC,
+        language="en",
+        format=NanoFormat.TEXT,
+        status=NanoStatus.PUBLISHED,
+        version="1.0.0",
+        license=LicenseType.CC_BY,
+    )
+    db_session.add(nano)
+    await db_session.commit()
+
+    token, _ = create_access_token(reporter.id, reporter.email, role=reporter.role.value)
+
+    not_found = await async_client.get(
+        f"/api/v1/nanos/{nano.id}/flags/my-flag",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert not_found.status_code == 404
+
+    create_response = await async_client.post(
+        f"/api/v1/nanos/{nano.id}/flags",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"reason": "other", "comment": "Needs moderator review"},
+    )
+    assert create_response.status_code == 201
+
+    found = await async_client.get(
+        f"/api/v1/nanos/{nano.id}/flags/my-flag",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert found.status_code == 200
+    payload = found.json()
+    assert payload["nano_id"] == str(nano.id)
+    assert payload["flagging_user_id"] == str(reporter.id)
+    assert payload["reason"] == "other"


### PR DESCRIPTION
Fixes #141

## Summary

This PR implements the core Story 6.3 user flagging workflow for Nanos, including persistence, API endpoints, moderation-queue integration, and regression tests.

### Problem

Users had no first-class way to report inappropriate published Nanos, and moderation cases reserved for flag reports were not populated by any backend flow.

### Solution

Added a dedicated `nano_flags` model and migration, created authenticated Nano flag endpoints, enforced duplicate/self-flag protections, and connected each new flag to moderation queue cases with reporter attribution. Added targeted tests for the full core reporting path.

---

## Changes

### Models & Migration
- Added `FlagReason`, `FlagStatus`, and `NanoFlag` SQLAlchemy model with unique `(nano_id, flagging_user_id)` constraint.
- Added migration `e8a1d7f4c2b9_add_nano_flags_table.py` creating `nano_flags`, indexes, and enum values.
- Extended `AuditAction` with `FLAG_CREATED` and `FLAG_REVIEWED`.

### Nano API & Service
- Added `POST /api/v1/nanos/{nano_id}/flags` for authenticated user reports.
- Added `GET /api/v1/nanos/{nano_id}/flags/my-flag` to fetch the caller's existing report.
- Enforced:
  - `403` when creators attempt to flag their own Nano.
  - `409` on duplicate user/nano reports.
  - `400` for non-published Nano reports.
- Added audit logging for flag creation.

### Moderation Integration
- Updated moderation upsert logic to accept and persist `reporter_id`.
- Added `FLAG` content detail enrichment for moderation queue responses.
- Added decision mapping to update `NanoFlag.status` lifecycle during moderation reviews.

### Schemas & Tests
- Added Nano flag request/response schemas.
- Added new backend test module `tests/modules/nanos/test_flags_routes.py` covering:
  - successful flag creation
  - duplicate prevention
  - self-flag forbidden
  - my-flag lookup behavior (404 then 200)
- Appended an implementation learning in `LEARNINGS.md` for robust flag guard patterns.

---

## Validation

| Check | Result |
|-------|--------|
| `black --check` | ✅ |
| `isort --check-only` | ✅ |
| `pytest tests/` | ✅ 482 passed, 1 skipped |
| Coverage | ✅ 72.63% (required: 70%) |