### PR TITLE
153: Fix verification mail localhost link in non-dev environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ APP_VERSION="0.1.0"
 DEBUG=False
 ENV="development"
 FRONTEND_URL="http://localhost:5173"
+# Public base URL for links sent via email (verification/reset links).
+# In production/staging, set this to your externally reachable domain, e.g.
+# PUBLIC_BASE_URL="https://nano.example.com"
+# Legacy alias supported: APP_BASE_URL
+PUBLIC_BASE_URL=""
 
 # Database Configuration
 # Choose ONE of the following based on your setup:

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -107,6 +107,7 @@ Kompaktes Regelwerk für Implementierung, Review und Qualitätssicherung.
 - Bei `docker-compose.yml`-`command: >` mit `/bin/sh -c` OpenSSL-Aufrufe als einzelne Kommandozeile (oder mit expliziten `\`-Fortsetzungen) schreiben; sonst können Flags wie `-keyout` als eigene Shell-Kommandos ausgeführt werden.
 - Nginx-Upstreams auf optionale Services (z. B. Grafana) nicht als statischen `upstream` beim Startup erzwingen: request-time DNS mit `resolver 127.0.0.11` + `proxy_pass http://$variable` verhindert `host not found`-Bootloops.
 - Service-URLs im Container: explizit setzen (kein `localhost`-Default).
+- Nach Docker-Image-Rebuilds mit geänderten Python-Abhängigkeiten den App-Container per `docker compose up -d --force-recreate app` neu erzeugen; ein bloßes `up -d` kann einen laufenden Container mit veraltetem Site-Packages-Stand stehen lassen.
 - Integrations-Tasks (`Test: Verified`): alle benötigten Services in Readiness-Checks (z. B. Mailpit + App/DB/Redis).
 - Runtime-Pfade (Root-Redirects, API-Bases) über Umgebungsvariablen steuern.
 - Services mit Host-Port-Mapping: zusätzlich nicht-internes Bridge-Netzwerk anbinden (nur `internal: true` – kein Host-Zugriff).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ cd frontend && npm install && npm run dev
 ```
 Frontend: http://localhost:5173
 
+Hinweis fuer Verifikationsmails:
+- In Staging/Produktion `PUBLIC_BASE_URL` auf die extern erreichbare URL setzen (z. B. `https://nano.example.com`).
+- `localhost`-Links sind nur fuer Development/Test gedacht.
+
 **Tests (lokal):**
 ```bash
 pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ cd frontend && npm install && npm run dev
 ```
 Frontend: http://localhost:5173
 
-Hinweis fuer Verifikationsmails:
+Hinweis für Verifikationsmails:
 - In Staging/Produktion `PUBLIC_BASE_URL` auf die extern erreichbare URL setzen (z. B. `https://nano.example.com`).
-- `localhost`-Links sind nur fuer Development/Test gedacht.
+- `localhost`-Links sind nur für Development/Test gedacht.
 
 **Tests (lokal):**
 ```bash

--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@
 
 from functools import lru_cache
 from typing import ClassVar, Optional
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, EmailStr, SecretStr, model_validator
 from pydantic_settings import BaseSettings
@@ -73,6 +74,8 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     ENV: str = "development"
     FRONTEND_URL: str = "http://localhost:5173"
+    PUBLIC_BASE_URL: Optional[str] = None
+    APP_BASE_URL: Optional[str] = None
 
     # Database settings
     DATABASE_URL: Optional[str] = None
@@ -169,6 +172,29 @@ class Settings(BaseSettings):
         """Apply environment defaults and validate SMTP transport settings."""
         if self.AUTH_RESEND_RETURN_TOKEN is None:
             self.AUTH_RESEND_RETURN_TOKEN = self.ENV in {"development", "test"}
+
+        effective_public_base_url = (
+            self.PUBLIC_BASE_URL or self.APP_BASE_URL or self.FRONTEND_URL
+        ).strip()
+        if not effective_public_base_url:
+            raise ValueError(
+                "Invalid URL configuration: set PUBLIC_BASE_URL/APP_BASE_URL or FRONTEND_URL."
+            )
+
+        if self.ENV not in {"development", "test"}:
+            parsed_url = urlparse(effective_public_base_url)
+            hostname = (parsed_url.hostname or "").lower()
+            if not hostname:
+                raise ValueError(
+                    "Invalid URL configuration: PUBLIC_BASE_URL/APP_BASE_URL/FRONTEND_URL "
+                    "must be an absolute URL in non-development environments."
+                )
+
+            if hostname in {"localhost", "127.0.0.1", "::1"}:
+                raise ValueError(
+                    "Invalid URL configuration: localhost URLs are not allowed for "
+                    "verification links outside development/test."
+                )
 
         _ = self.smtp_settings
 

--- a/app/config.py
+++ b/app/config.py
@@ -169,15 +169,17 @@ class Settings(BaseSettings):
 
     @property
     def effective_verification_base_url(self) -> str:
-        """Return the base URL to use for email verification links.
+        """Return normalized base URL for verification links.
 
-        Resolution order: PUBLIC_BASE_URL → APP_BASE_URL → FRONTEND_URL.
-        Trailing slashes are stripped so callers can safely append paths.
+        URL precedence is PUBLIC_BASE_URL -> APP_BASE_URL -> FRONTEND_URL.
         """
         for candidate in (self.PUBLIC_BASE_URL, self.APP_BASE_URL, self.FRONTEND_URL):
             if candidate and candidate.strip():
-                return candidate.rstrip("/")
-        raise RuntimeError("No base URL configured for email verification links")
+                return candidate.strip().rstrip("/")
+
+        raise ValueError(
+            "Invalid URL configuration: set PUBLIC_BASE_URL/APP_BASE_URL or FRONTEND_URL."
+        )
 
     @model_validator(mode="after")
     def validate_settings(self) -> "Settings":
@@ -188,11 +190,17 @@ class Settings(BaseSettings):
         effective_public_base_url = self.effective_verification_base_url
         if self.ENV not in {"development", "test"}:
             parsed_url = urlparse(effective_public_base_url)
+            if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+                raise ValueError(
+                    "Invalid URL configuration: PUBLIC_BASE_URL/APP_BASE_URL/FRONTEND_URL "
+                    "must be an absolute http(s) URL in non-development environments."
+                )
+
             hostname = (parsed_url.hostname or "").lower()
             if not hostname:
                 raise ValueError(
                     "Invalid URL configuration: PUBLIC_BASE_URL/APP_BASE_URL/FRONTEND_URL "
-                    "must be an absolute URL in non-development environments."
+                    "must include a valid hostname in non-development environments."
                 )
 
             if hostname in {"localhost", "127.0.0.1", "::1"}:

--- a/app/config.py
+++ b/app/config.py
@@ -167,20 +167,25 @@ class Settings(BaseSettings):
     UPLOAD_MAX_RETRIES: int = 3
     UPLOAD_TIMEOUT_SECONDS: int = 600
 
+    @property
+    def effective_verification_base_url(self) -> str:
+        """Return the base URL to use for email verification links.
+
+        Resolution order: PUBLIC_BASE_URL → APP_BASE_URL → FRONTEND_URL.
+        Trailing slashes are stripped so callers can safely append paths.
+        """
+        for candidate in (self.PUBLIC_BASE_URL, self.APP_BASE_URL, self.FRONTEND_URL):
+            if candidate and candidate.strip():
+                return candidate.rstrip("/")
+        raise RuntimeError("No base URL configured for email verification links")
+
     @model_validator(mode="after")
-    def validate_smtp_transport_flags(self) -> "Settings":
-        """Apply environment defaults and validate SMTP transport settings."""
+    def validate_settings(self) -> "Settings":
+        """Apply environment defaults and validate settings after construction."""
         if self.AUTH_RESEND_RETURN_TOKEN is None:
             self.AUTH_RESEND_RETURN_TOKEN = self.ENV in {"development", "test"}
 
-        effective_public_base_url = (
-            self.PUBLIC_BASE_URL or self.APP_BASE_URL or self.FRONTEND_URL
-        ).strip()
-        if not effective_public_base_url:
-            raise ValueError(
-                "Invalid URL configuration: set PUBLIC_BASE_URL/APP_BASE_URL or FRONTEND_URL."
-            )
-
+        effective_public_base_url = self.effective_verification_base_url
         if self.ENV not in {"development", "test"}:
             parsed_url = urlparse(effective_public_base_url)
             hostname = (parsed_url.hostname or "").lower()

--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -124,10 +124,20 @@ def _get_user_agent(request: Request) -> str:
     return request.headers.get("user-agent", "")
 
 
+def _get_public_verification_base_url() -> str:
+    """Resolve the base URL used for verification links in auth emails."""
+    for candidate in (settings.PUBLIC_BASE_URL, settings.APP_BASE_URL, settings.FRONTEND_URL):
+        if candidate and candidate.strip():
+            return candidate.rstrip("/")
+
+    # Guard clause to keep link generation deterministic if config is corrupted.
+    raise RuntimeError("No base URL configured for email verification links")
+
+
 def _build_verification_url(token: str, email: str) -> str:
     """Build the frontend verification URL embedded in auth emails."""
     query = urlencode({"token": token, "email": email})
-    return f"{settings.FRONTEND_URL.rstrip('/')}/verify-email?{query}"
+    return f"{_get_public_verification_base_url()}/verify-email?{query}"
 
 
 async def _send_verification_mail(

--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -126,12 +126,7 @@ def _get_user_agent(request: Request) -> str:
 
 def _get_public_verification_base_url() -> str:
     """Resolve the base URL used for verification links in auth emails."""
-    for candidate in (settings.PUBLIC_BASE_URL, settings.APP_BASE_URL, settings.FRONTEND_URL):
-        if candidate and candidate.strip():
-            return candidate.rstrip("/")
-
-    # Guard clause to keep link generation deterministic if config is corrupted.
-    raise RuntimeError("No base URL configured for email verification links")
+    return settings.effective_verification_base_url
 
 
 def _build_verification_url(token: str, email: str) -> str:

--- a/tests/modules/auth/test_email_verification.py
+++ b/tests/modules/auth/test_email_verification.py
@@ -401,6 +401,42 @@ async def test_resend_verification_email_uses_public_base_url_when_configured(
 
 
 @pytest.mark.asyncio
+async def test_resend_verification_email_uses_app_base_url_as_middle_option(
+    async_client,
+    db_session: AsyncSession,
+    verified_user: User,
+    sent_auth_emails,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verification mails should use APP_BASE_URL when PUBLIC_BASE_URL is not configured."""
+    verified_user.email_verified = False
+    verified_user.verified_at = None
+    db_session.add(verified_user)
+    await db_session.commit()
+
+    monkeypatch.setattr("app.modules.auth.router.settings.AUTH_RESEND_RETURN_TOKEN", False)
+    monkeypatch.setattr("app.modules.auth.router.settings.ENV", "production")
+    monkeypatch.setattr("app.modules.auth.router.settings.PUBLIC_BASE_URL", None)
+    monkeypatch.setattr(
+        "app.modules.auth.router.settings.APP_BASE_URL", "https://app.nano.example.com"
+    )
+    monkeypatch.setattr("app.modules.auth.router.settings.FRONTEND_URL", "http://localhost:5173")
+
+    response = await async_client.post(
+        "/api/v1/auth/resend-verification-email", json={"email": verified_user.email}
+    )
+
+    expect(response.status_code).equal(200)
+    delivered_mail = sent_auth_emails[-1]
+    verification_link = _extract_verification_link_from_mail_body(delivered_mail["body_text"])
+
+    parsed_link = urlparse(verification_link)
+    expect(parsed_link.scheme).equal("https")
+    expect(parsed_link.netloc).equal("app.nano.example.com")
+    expect(parsed_link.path).equal("/verify-email")
+
+
+@pytest.mark.asyncio
 async def test_resend_verification_email_falls_back_to_frontend_url_in_development(
     async_client,
     db_session: AsyncSession,

--- a/tests/modules/auth/test_email_verification.py
+++ b/tests/modules/auth/test_email_verification.py
@@ -435,6 +435,47 @@ async def test_resend_verification_email_falls_back_to_frontend_url_in_developme
 
 
 @pytest.mark.asyncio
+async def test_resend_verification_email_uses_app_base_url_when_public_base_url_unset(
+    async_client,
+    db_session: AsyncSession,
+    verified_user: User,
+    sent_auth_emails,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verification mails fall back to APP_BASE_URL when PUBLIC_BASE_URL is not set."""
+    # This exercises the middle option in the PUBLIC_BASE_URL → APP_BASE_URL → FRONTEND_URL
+    # resolution chain to ensure APP_BASE_URL (legacy alias) is not silently bypassed.
+    verified_user.email_verified = False
+    verified_user.verified_at = None
+    db_session.add(verified_user)
+    await db_session.commit()
+
+    monkeypatch.setattr("app.modules.auth.router.settings.AUTH_RESEND_RETURN_TOKEN", False)
+    monkeypatch.setattr("app.modules.auth.router.settings.ENV", "staging")
+    monkeypatch.setattr("app.modules.auth.router.settings.FRONTEND_URL", "http://localhost:5173")
+    monkeypatch.setattr("app.modules.auth.router.settings.PUBLIC_BASE_URL", None)
+    monkeypatch.setattr(
+        "app.modules.auth.router.settings.APP_BASE_URL", "https://staging.nano.example.com"
+    )
+
+    response = await async_client.post(
+        "/api/v1/auth/resend-verification-email", json={"email": verified_user.email}
+    )
+
+    expect(response.status_code).equal(200)
+    delivered_mail = sent_auth_emails[-1]
+    verification_link = _extract_verification_link_from_mail_body(delivered_mail["body_text"])
+
+    parsed_link = urlparse(verification_link)
+    expect(parsed_link.scheme).equal("https")
+    expect(parsed_link.netloc).equal("staging.nano.example.com")
+    expect(parsed_link.path).equal("/verify-email")
+    query = parse_qs(parsed_link.query)
+    expect(query.get("email", [""])[0]).equal(verified_user.email)
+    expect(query.get("token", [""])[0]).is_not_none()
+
+
+@pytest.mark.asyncio
 async def test_resend_verification_email_endpoint_smtp_failure_returns_safe_503(
     async_client,
     db_session: AsyncSession,

--- a/tests/modules/auth/test_email_verification.py
+++ b/tests/modules/auth/test_email_verification.py
@@ -42,6 +42,14 @@ def _extract_token_from_mail_body(body_text: str) -> str:
     raise AssertionError("Verification token link not found in body_text")
 
 
+def _extract_verification_link_from_mail_body(body_text: str) -> str:
+    for line in body_text.splitlines():
+        if "/verify-email?" in line:
+            return line.strip()
+
+    raise AssertionError("Verification link not found in body_text")
+
+
 @pytest.mark.asyncio
 async def test_create_email_verification_token() -> None:
     """Test creating an email verification token.
@@ -351,6 +359,79 @@ async def test_resend_verification_email_endpoint_sends_mail_when_toggle_disable
     expect(delivered_mail["subject"]).equal("Your new verification link")
     token = _extract_token_from_mail_body(delivered_mail["body_text"])
     expect(token).is_not_none()
+
+
+@pytest.mark.asyncio
+async def test_resend_verification_email_uses_public_base_url_when_configured(
+    async_client,
+    db_session: AsyncSession,
+    verified_user: User,
+    sent_auth_emails,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verification mails should prefer PUBLIC_BASE_URL over FRONTEND_URL."""
+    verified_user.email_verified = False
+    verified_user.verified_at = None
+    db_session.add(verified_user)
+    await db_session.commit()
+
+    monkeypatch.setattr("app.modules.auth.router.settings.AUTH_RESEND_RETURN_TOKEN", False)
+    monkeypatch.setattr("app.modules.auth.router.settings.ENV", "production")
+    monkeypatch.setattr("app.modules.auth.router.settings.FRONTEND_URL", "http://localhost:5173")
+    monkeypatch.setattr(
+        "app.modules.auth.router.settings.PUBLIC_BASE_URL", "https://nano.example.com"
+    )
+    monkeypatch.setattr("app.modules.auth.router.settings.APP_BASE_URL", None)
+
+    response = await async_client.post(
+        "/api/v1/auth/resend-verification-email", json={"email": verified_user.email}
+    )
+
+    expect(response.status_code).equal(200)
+    delivered_mail = sent_auth_emails[-1]
+    verification_link = _extract_verification_link_from_mail_body(delivered_mail["body_text"])
+
+    parsed_link = urlparse(verification_link)
+    expect(parsed_link.scheme).equal("https")
+    expect(parsed_link.netloc).equal("nano.example.com")
+    expect(parsed_link.path).equal("/verify-email")
+    query = parse_qs(parsed_link.query)
+    expect(query.get("email", [""])[0]).equal(verified_user.email)
+    expect(query.get("token", [""])[0]).is_not_none()
+
+
+@pytest.mark.asyncio
+async def test_resend_verification_email_falls_back_to_frontend_url_in_development(
+    async_client,
+    db_session: AsyncSession,
+    verified_user: User,
+    sent_auth_emails,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Development flow should still allow localhost FRONTEND_URL fallback."""
+    verified_user.email_verified = False
+    verified_user.verified_at = None
+    db_session.add(verified_user)
+    await db_session.commit()
+
+    monkeypatch.setattr("app.modules.auth.router.settings.AUTH_RESEND_RETURN_TOKEN", False)
+    monkeypatch.setattr("app.modules.auth.router.settings.ENV", "development")
+    monkeypatch.setattr("app.modules.auth.router.settings.PUBLIC_BASE_URL", None)
+    monkeypatch.setattr("app.modules.auth.router.settings.APP_BASE_URL", None)
+    monkeypatch.setattr("app.modules.auth.router.settings.FRONTEND_URL", "http://localhost:5173")
+
+    response = await async_client.post(
+        "/api/v1/auth/resend-verification-email", json={"email": verified_user.email}
+    )
+
+    expect(response.status_code).equal(200)
+    delivered_mail = sent_auth_emails[-1]
+    verification_link = _extract_verification_link_from_mail_body(delivered_mail["body_text"])
+
+    parsed_link = urlparse(verification_link)
+    expect(parsed_link.scheme).equal("http")
+    expect(parsed_link.netloc).equal("localhost:5173")
+    expect(parsed_link.path).equal("/verify-email")
 
 
 @pytest.mark.asyncio

--- a/tests/modules/test_config_smtp.py
+++ b/tests/modules/test_config_smtp.py
@@ -69,6 +69,7 @@ def test_smtp_plaintext_rejected_in_production() -> None:
     with pytest.raises(ValidationError, match="not allowed in production"):
         Settings(
             ENV="production",
+            PUBLIC_BASE_URL="https://nano.example.com",
             SMTP_USE_TLS=False,
             SMTP_USE_STARTTLS=False,
         )
@@ -102,6 +103,7 @@ def test_smtp_production_rejects_development_defaults() -> None:
     with pytest.raises(ValidationError, match="production requires explicit SMTP_HOST"):
         Settings(
             ENV="production",
+            PUBLIC_BASE_URL="https://nano.example.com",
             SMTP_USE_TLS=False,
             SMTP_USE_STARTTLS=True,
         )
@@ -111,6 +113,7 @@ def test_smtp_production_accepts_explicit_values() -> None:
     """Production settings accept explicit SMTP credentials and sender values."""
     settings = Settings(
         ENV="production",
+        PUBLIC_BASE_URL="https://nano.example.com",
         SMTP_HOST="smtp.example.com",
         SMTP_PORT=587,
         SMTP_USERNAME="mailer",


### PR DESCRIPTION
Fixes #153

## Summary

This PR fixes email verification link generation so auth mails use an externally reachable base URL in staging/production, while preserving localhost behavior for development and test environments.

### Problem

Verification emails built links from a localhost-oriented base URL, causing unusable verification links in non-local deployments where users must access the app via a public domain or fixed IP.

### Solution

Introduce configurable public base URL support with clear precedence (PUBLIC_BASE_URL -> APP_BASE_URL -> FRONTEND_URL), enforce non-localhost absolute URLs outside development/test, and centralize verification-link construction in the auth router. Add targeted tests for production-style and development link generation and update environment/documentation guidance.

---

## Changes

### Configuration
- Added PUBLIC_BASE_URL and APP_BASE_URL settings in pp/config.py.
- Added validation that non-development environments must use an absolute non-localhost base URL for verification links.
- Kept development/test fallback behavior compatible with localhost setups.

### Auth Router
- Centralized verification base URL resolution in pp/modules/auth/router.py.
- Updated verification-link generation to use resolved public base URL instead of hardcoding FRONTEND_URL directly.

### Tests
- Added integration-level verification mail assertions for production-style external URL usage.
- Added development fallback test that confirms localhost link behavior remains intact.
- Updated SMTP production config tests to include explicit PUBLIC_BASE_URL where production settings are instantiated.

### Documentation
- Updated .env.example with PUBLIC_BASE_URL guidance and APP_BASE_URL alias note.
- Updated README.md with verification mail URL configuration guidance.
- Added a runtime learning to LEARNINGS.md about force-recreating app containers after dependency-affecting image rebuilds.

---

## Validation

| Check | Result |
|-------|--------|
| lack --check | ✅ |
| isort --check-only | ✅ |
| pytest tests/ | ✅ 493 passed, 1 skipped |
| Coverage | ✅ 72.72% (required: 70%) |
| Docker services | ✅ All healthy during full integration run (Test: Verified) |