### PR TITLE
157: Fix verification link generation for schema-less PUBLIC_BASE_URL

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -54,6 +54,7 @@ Kompaktes Regelwerk für Implementierung, Review und Qualitätssicherung.
 - CORS: Credentials nur mit expliziten Origins (nie `*`).
 - Infrastrukturfehler am API-Rand gezielt auf stabile HTTP-Fehler mappen.
 - In FastAPI `HTTP_422_UNPROCESSABLE_CONTENT` statt `HTTP_422_UNPROCESSABLE_ENTITY` (vermeidet DeprecationWarnings).
+- Für Base-URL-Normalisierung ist `urlparse()` allein bei schema-losen `host:port`-Werten unzuverlässig (`host` wird als `scheme` interpretiert); robustes Schema-Detection über `://` (plus Empty-Check nach `rstrip('/')`) verhindert fehlerhafte Verifikationslinks.
 
 ### Data Integrity & Error Handling
 - DB-Constraints + Service-Guards kombinieren (z. B. `UNIQUE` + 409-Precheck + `IntegrityError`-Handling).

--- a/app/config.py
+++ b/app/config.py
@@ -176,11 +176,14 @@ class Settings(BaseSettings):
         for candidate in (self.PUBLIC_BASE_URL, self.APP_BASE_URL, self.FRONTEND_URL):
             if candidate and candidate.strip():
                 normalized = candidate.strip().rstrip("/")
-                parsed = urlparse(normalized)
+                if not normalized:
+                    continue
 
                 # In development/test we accept host-only URLs (e.g. 141.41.42.209)
                 # and normalize them to absolute URLs for stable mail links.
-                if not parsed.scheme and self.ENV in {"development", "test"}:
+                # Use :// to detect an explicit URI scheme because urlparse()
+                # interprets schema-less host:port values as a "scheme".
+                if self.ENV in {"development", "test"} and "://" not in normalized:
                     normalized = f"http://{normalized.lstrip('/')}"
 
                 return normalized

--- a/app/config.py
+++ b/app/config.py
@@ -175,7 +175,15 @@ class Settings(BaseSettings):
         """
         for candidate in (self.PUBLIC_BASE_URL, self.APP_BASE_URL, self.FRONTEND_URL):
             if candidate and candidate.strip():
-                return candidate.strip().rstrip("/")
+                normalized = candidate.strip().rstrip("/")
+                parsed = urlparse(normalized)
+
+                # In development/test we accept host-only URLs (e.g. 141.41.42.209)
+                # and normalize them to absolute URLs for stable mail links.
+                if not parsed.scheme and self.ENV in {"development", "test"}:
+                    normalized = f"http://{normalized.lstrip('/')}"
+
+                return normalized
 
         raise ValueError(
             "Invalid URL configuration: set PUBLIC_BASE_URL/APP_BASE_URL or FRONTEND_URL."

--- a/tests/modules/auth/test_email_verification.py
+++ b/tests/modules/auth/test_email_verification.py
@@ -471,6 +471,40 @@ async def test_resend_verification_email_falls_back_to_frontend_url_in_developme
 
 
 @pytest.mark.asyncio
+async def test_resend_verification_email_normalizes_host_only_public_base_url_in_development(
+    async_client,
+    db_session: AsyncSession,
+    verified_user: User,
+    sent_auth_emails,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Development flow should normalize PUBLIC_BASE_URL without schema to http://..."""
+    verified_user.email_verified = False
+    verified_user.verified_at = None
+    db_session.add(verified_user)
+    await db_session.commit()
+
+    monkeypatch.setattr("app.modules.auth.router.settings.AUTH_RESEND_RETURN_TOKEN", False)
+    monkeypatch.setattr("app.modules.auth.router.settings.ENV", "development")
+    monkeypatch.setattr("app.modules.auth.router.settings.PUBLIC_BASE_URL", "141.41.42.209")
+    monkeypatch.setattr("app.modules.auth.router.settings.APP_BASE_URL", None)
+    monkeypatch.setattr("app.modules.auth.router.settings.FRONTEND_URL", "http://localhost:5173")
+
+    response = await async_client.post(
+        "/api/v1/auth/resend-verification-email", json={"email": verified_user.email}
+    )
+
+    expect(response.status_code).equal(200)
+    delivered_mail = sent_auth_emails[-1]
+    verification_link = _extract_verification_link_from_mail_body(delivered_mail["body_text"])
+
+    parsed_link = urlparse(verification_link)
+    expect(parsed_link.scheme).equal("http")
+    expect(parsed_link.netloc).equal("141.41.42.209")
+    expect(parsed_link.path).equal("/verify-email")
+
+
+@pytest.mark.asyncio
 async def test_resend_verification_email_uses_app_base_url_when_public_base_url_unset(
     async_client,
     db_session: AsyncSession,

--- a/tests/modules/auth/test_email_verification.py
+++ b/tests/modules/auth/test_email_verification.py
@@ -505,6 +505,40 @@ async def test_resend_verification_email_normalizes_host_only_public_base_url_in
 
 
 @pytest.mark.asyncio
+async def test_resend_verification_email_normalizes_host_port_public_base_url_in_development(
+    async_client,
+    db_session: AsyncSession,
+    verified_user: User,
+    sent_auth_emails,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Development flow should normalize schema-less host:port PUBLIC_BASE_URL values."""
+    verified_user.email_verified = False
+    verified_user.verified_at = None
+    db_session.add(verified_user)
+    await db_session.commit()
+
+    monkeypatch.setattr("app.modules.auth.router.settings.AUTH_RESEND_RETURN_TOKEN", False)
+    monkeypatch.setattr("app.modules.auth.router.settings.ENV", "development")
+    monkeypatch.setattr("app.modules.auth.router.settings.PUBLIC_BASE_URL", "141.41.42.209:5173")
+    monkeypatch.setattr("app.modules.auth.router.settings.APP_BASE_URL", None)
+    monkeypatch.setattr("app.modules.auth.router.settings.FRONTEND_URL", "http://localhost:5173")
+
+    response = await async_client.post(
+        "/api/v1/auth/resend-verification-email", json={"email": verified_user.email}
+    )
+
+    expect(response.status_code).equal(200)
+    delivered_mail = sent_auth_emails[-1]
+    verification_link = _extract_verification_link_from_mail_body(delivered_mail["body_text"])
+
+    parsed_link = urlparse(verification_link)
+    expect(parsed_link.scheme).equal("http")
+    expect(parsed_link.netloc).equal("141.41.42.209:5173")
+    expect(parsed_link.path).equal("/verify-email")
+
+
+@pytest.mark.asyncio
 async def test_resend_verification_email_uses_app_base_url_when_public_base_url_unset(
     async_client,
     db_session: AsyncSession,


### PR DESCRIPTION
## Summary
Fixes #157

This PR normalizes schema-less PUBLIC_BASE_URL/APP_BASE_URL values in development/test environments so verification links are always absolute URLs.

## Changes
- Update effective verification base URL resolution in settings:
  - If ENV is development/test and URL has no scheme, normalize to http://<value>
- Add regression test for resend verification flow:
  - PUBLIC_BASE_URL="141.41.42.209" in development generates
    http://141.41.42.209/verify-email?... links

## Validation
- Checks task: passed (black/isort)
- Full backend tests: 496 passed, 1 skipped (coverage 72.77%)
