### PR TITLE
159: Remove redundant email query parameter from verification links

### DIFF
--- a/app/modules/auth/router.py
+++ b/app/modules/auth/router.py
@@ -129,9 +129,9 @@ def _get_public_verification_base_url() -> str:
     return settings.effective_verification_base_url
 
 
-def _build_verification_url(token: str, email: str) -> str:
+def _build_verification_url(token: str) -> str:
     """Build the frontend verification URL embedded in auth emails."""
-    query = urlencode({"token": token, "email": email})
+    query = urlencode({"token": token})
     return f"{_get_public_verification_base_url()}/verify-email?{query}"
 
 
@@ -145,7 +145,7 @@ async def _send_verification_mail(
 ) -> None:
     """Render and send a verification mail with stable SMTP error mapping."""
     correlation_id = str(uuid4())
-    payload = template_builder(username, _build_verification_url(token, email))
+    payload = template_builder(username, _build_verification_url(token))
 
     set_mail_context(payload.message_type, correlation_id)
 

--- a/tests/modules/auth/test_email_verification.py
+++ b/tests/modules/auth/test_email_verification.py
@@ -396,7 +396,7 @@ async def test_resend_verification_email_uses_public_base_url_when_configured(
     expect(parsed_link.netloc).equal("nano.example.com")
     expect(parsed_link.path).equal("/verify-email")
     query = parse_qs(parsed_link.query)
-    expect(query.get("email", [""])[0]).equal(verified_user.email)
+    expect(query.get("email")).is_none()
     expect(query.get("token", [""])[0]).is_not_none()
 
 
@@ -575,7 +575,7 @@ async def test_resend_verification_email_uses_app_base_url_when_public_base_url_
     expect(parsed_link.netloc).equal("staging.nano.example.com")
     expect(parsed_link.path).equal("/verify-email")
     query = parse_qs(parsed_link.query)
-    expect(query.get("email", [""])[0]).equal(verified_user.email)
+    expect(query.get("email")).is_none()
     expect(query.get("token", [""])[0]).is_not_none()
 
 

--- a/tests/modules/auth/test_email_verification.py
+++ b/tests/modules/auth/test_email_verification.py
@@ -397,7 +397,10 @@ async def test_resend_verification_email_uses_public_base_url_when_configured(
     expect(parsed_link.path).equal("/verify-email")
     query = parse_qs(parsed_link.query)
     expect(query.get("email")).is_none()
-    expect(query.get("token", [""])[0]).is_not_none()
+    token_values = query.get("token")
+    expect(token_values).is_not_none()
+    assert token_values is not None
+    expect(token_values[0]).is_not_equal("")
 
 
 @pytest.mark.asyncio
@@ -576,7 +579,10 @@ async def test_resend_verification_email_uses_app_base_url_when_public_base_url_
     expect(parsed_link.path).equal("/verify-email")
     query = parse_qs(parsed_link.query)
     expect(query.get("email")).is_none()
-    expect(query.get("token", [""])[0]).is_not_none()
+    token_values = query.get("token")
+    expect(token_values).is_not_none()
+    assert token_values is not None
+    expect(token_values[0]).is_not_equal("")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- remove redundant email query parameter from verification links in auth mails\n- keep verification flow token-only (/verify-email?token=...)\n- update auth verification tests to assert that email is not present in query string\n\n## Validation\n- Checks task passed (black/isort)\n- Test: Verified task passed\n- Quick Test Status: 497 passed, 1 skipped, coverage 72.80%\n\nCloses #159